### PR TITLE
Fix for aws_cfn_stack running under chef-zero on Windows (no more template file stage)

### DIFF
--- a/providers/cfn_stack.rb
+++ b/providers/cfn_stack.rb
@@ -18,7 +18,7 @@ def build_cfn_options
   unless new_resource.stack_policy_body.nil?
     options[:stack_policy_body] = new_resource.stack_policy_body
   end
-  options[:capabilities] = ["CAPABILITY_IAM"] if new_resource.iam_capability
+  options[:capabilities] = ['CAPABILITY_IAM'] if new_resource.iam_capability
   options
 end
 
@@ -77,14 +77,13 @@ action :delete do
   end
 end
 
-
 private
 
 def load_template_path
   cookbook = run_context.cookbook_collection[new_resource.cookbook_name]
   file_cache_location = cookbook.preferred_filename_on_disk_location(run_context.node, :files, new_resource.template_source)
   if file_cache_location.nil?
-    raise "Cannot find #{new_resource.template_source} in cookbook!"
+    fail "Cannot find #{new_resource.template_source} in cookbook!"
   else
     @template_path = file_cache_location
   end


### PR DESCRIPTION
This PR removes the `cookbook_file` staging feature of the `aws_cnf_stack` resource.

This in particularly was causing issues on Windows machines attempting to run consuming cookbooks under `chef-zero`.
